### PR TITLE
Add support for custom out of page ad slots via CUSTOM type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "indent": ["error", "space"],
+    "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single"],
     "semi": ["error", "never"]

--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ The prop is set in **milliseconds**.
 
 Define Out-of-page formats supported by Google Tag Manger. See more information at [Enum Types - Google Developers](https://developers.google.com/publisher-tag/reference#googletag.enums.outofpageformat).
 
+For custom out-of-page ad slot use the `CUSTOM` value combined with the `name` Ad Prop. See more information about the [defineOutOfPageSlot](https://developers.google.com/publisher-tag/reference#googletag.defineOutOfPageSlot)
+
 - **type:** string
 - **required:** false
-- **value:** 'INTERSTITIAL' | 'TOP_ANCHOR' | 'BOTTOM_ANCHOR' | undefined
+- **value:** 'INTERSTITIAL' | 'TOP_ANCHOR' | 'BOTTOM_ANCHOR' | 'CUSTOM' | undefined
 
 #### `eventSlotOnload`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-ad-manager",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-ad-manager",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.2.21",

--- a/src/components/Ad.tsx
+++ b/src/components/Ad.tsx
@@ -44,10 +44,17 @@ const Ad: React.FC<AdType> = ({
 
   const displayEspecialAd = () => {
     googletag.cmd.push(() => {
-      adSlot = googletag.defineOutOfPageSlot(
-        `${variables.networkCode.get()}${adUnit}`,
-        googletag.enums.OutOfPageFormat[type]
-      )
+      if (type === 'CUSTOM' && name) {
+        adSlot = googletag.defineOutOfPageSlot(
+          `${variables.networkCode.get()}${adUnit}`,
+          name
+        )
+      } else {
+        adSlot = googletag.defineOutOfPageSlot(
+          `${variables.networkCode.get()}${adUnit}`,
+          googletag.enums.OutOfPageFormat[type]
+        )
+      }
       if (adSlot) {
         adSlot.setTargeting('type', type)
         adSlot.addService(googletag.pubads())
@@ -160,7 +167,7 @@ const Ad: React.FC<AdType> = ({
     }
   }, [])
 
-  if (type) return null
+  if (type && type !== 'CUSTOM') return null
 
   return <div id={name}></div>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export type AdType = {
   name?: string
   size?: AdSizeType
   target?: TargetArrayType
-  type?: 'INTERSTITIAL' | 'TOP_ANCHOR' | 'BOTTOM_ANCHOR'
+  type?: 'INTERSTITIAL' | 'TOP_ANCHOR' | 'BOTTOM_ANCHOR' | 'CUSTOM'
   refreshTimer?: number | string
   eventImpressionViewable?: any
   eventSlotOnload?: any


### PR DESCRIPTION
This PR adds support for out of page ad with custom slots, which is one of the ways you can define out of page ad slots like the google documentation shows https://developers.google.com/publisher-tag/reference#googletag.defineOutOfPageSlot

I decided to add a new type called `CUSTOM` to the `type` Ad Prop, which when combined with the `name` Ad Prop allows to destinguish when to render a custom ad slot, from a GPT managed web ad slot (this for Out Of Page Slots) 

The other types (`'INTERSTITIAL' | 'TOP_ANCHOR' | 'BOTTOM_ANCHOR'`) still work as expected. 

Cheers!

